### PR TITLE
[WIP] Change packaging 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
-target/
+/count-network-lines-tool/target/
+/csv-exporter/target/
+/csv-importer/target/
+/itools-packager/target/
+/javafx-packager/target/
+/target/
 
 # IntelliJ
 .idea

--- a/count-network-lines-tool/pom.xml
+++ b/count-network-lines-tool/pom.xml
@@ -18,7 +18,7 @@
         <version>1.0.0</version>
     </parent>
 
-    <artifactId>powsybl-count-network-lines</artifactId>
+    <artifactId>powsybl-count-network-lines-tool</artifactId>
 
     <dependencies>
         <dependency>

--- a/count-network-lines-tool/src/main/java/com/powsybl/tutorials/tools/CountNetworkLinesTool.java
+++ b/count-network-lines-tool/src/main/java/com/powsybl/tutorials/tools/CountNetworkLinesTool.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package powsybl.tutorials.tools;
+package com.powsybl.tutorials.tools;
 
 import java.nio.file.Path;
 

--- a/csv-exporter/src/main/java/com/powsybl/tutorials/csv/exporter/CsvLinesExporter.java
+++ b/csv-exporter/src/main/java/com/powsybl/tutorials/csv/exporter/CsvLinesExporter.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package powsybl.tutorials.csv.export;
+package com.powsybl.tutorials.csv.exporter;
 
 import com.google.auto.service.AutoService;
 import com.powsybl.commons.datasource.DataSource;

--- a/csv-exporter/src/main/java/com/powsybl/tutorials/csv/exporter/Main.java
+++ b/csv-exporter/src/main/java/com/powsybl/tutorials/csv/exporter/Main.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package powsybl.tutorials.csv.export;
+package com.powsybl.tutorials.csv.exporter;
 
 import com.powsybl.iidm.export.Exporters;
 import com.powsybl.iidm.network.Network;

--- a/csv-importer/src/main/java/com/powsybl/tutorials/csv/importer/CsvLinesImporter.java
+++ b/csv-importer/src/main/java/com/powsybl/tutorials/csv/importer/CsvLinesImporter.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package powsybl.tutorials.csv.import_;
+package com.powsybl.tutorials.csv.importer;
 
 import com.csvreader.CsvReader;
 import com.google.auto.service.AutoService;

--- a/csv-importer/src/main/java/com/powsybl/tutorials/csv/importer/Main.java
+++ b/csv-importer/src/main/java/com/powsybl/tutorials/csv/importer/Main.java
@@ -4,7 +4,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-package powsybl.tutorials.csv.import_;
+package com.powsybl.tutorials.csv.importer;
 
 import com.powsybl.iidm.import_.Importers;
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     </properties>
 
     <modules>
-        <module>count-network-lines</module>
+        <module>count-network-lines-tool</module>
         <module>csv-exporter</module>
         <module>csv-importer</module>
         <module>itools-packager</module>


### PR DESCRIPTION
com.powsybl.tutorials + importer/exporter instead…of import_/export + count-network-lines-tool instead of count-network-lines

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Change in packaging:
- `com.powsybl.tutorials` instead of `powsybl.tutorials` (consistency)
- `import_` and `export` are renamed `importer` and `exporter`
- `count-network-lines` is renamed `count-network-lines-tool` to make it clear it is a tutorial for tool (itools command)
