### PR TITLE
Update to new releases of powsybl-core (3.1.0) and powsybl-rte-core (2.8.1).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <slf4j.version>1.7.22</slf4j.version>
 
         <powsybl.core.version>3.1.0</powsybl.core.version>
-        <powsybl.gse.version>1.7.0</powsybl.gse.version>
+        <powsybl.gse.version>1.8.0</powsybl.gse.version>
         <powsybl.rte-core.version>2.8.1</powsybl.rte-core.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,9 +40,9 @@
         <logback.version>1.1.8</logback.version>
         <slf4j.version>1.7.22</slf4j.version>
 
-        <powsybl.core.version>3.0.0</powsybl.core.version>
+        <powsybl.core.version>3.1.0</powsybl.core.version>
         <powsybl.gse.version>1.7.0</powsybl.gse.version>
-        <powsybl.rte-core.version>2.7.0</powsybl.rte-core.version>
+        <powsybl.rte-core.version>2.8.1</powsybl.rte-core.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
Signed-off-by: Anne Tilloy <atilloy@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*

No, but: tutorials depend on powsybl-core 3.0.0 and powsybl-rte-core 2.7.0. A new version of Hades2 is available (V6.4.0.1., please visit https://github.com/rte-france/hades2-distribution) that works with the last releases of powsybl-core and powsybl-rte-core (3.1.0 and 2.8.1).

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*

Good dependencies, see above.

**What is the current behavior?** *(You can also link to an open issue here)*



**What is the new behavior (if this is a feature change)?**



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
