### PR TITLE
Add config-classic to itools-packager tutorial, fixes the startup crash

### DIFF
--- a/itools-packager/pom.xml
+++ b/itools-packager/pom.xml
@@ -59,6 +59,12 @@
         </dependency>
         <dependency>
             <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-config-classic</artifactId>
+            <version>${powsybl.core.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.powsybl</groupId>
             <artifactId>powsybl-tools</artifactId>
             <version>${powsybl.core.version}</version>
             <scope>runtime</scope>


### PR DESCRIPTION
Signed-off-by: Jon Harper <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
2020-02-10_11:00:55.156 [main] ERROR c.p.commons.config.PlatformConfig - Platform configuration provider not found. For tests, consider using TestPlatformConfigProvider in powsybl-config-test. Otherwise, consider using ClassicPlatformConfigProvider from powsybl-config-classic.
Exception in thread "main" com.powsybl.commons.PowsyblException: Platform configuration provider not found
	at com.powsybl.commons.config.PlatformConfig.defaultConfig(PlatformConfig.java:70)
	at com.powsybl.computation.DefaultComputationManagerConfig.load(DefaultComputationManagerConfig.java:43)
	at com.powsybl.tools.Main.main(Main.java:28)



**What is the new behavior (if this is a feature change)?**
no exception


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
