### PR TITLE
Fix double loadflow computation for second network variant

### DIFF
--- a/loadflow/src/main/java/com/powsybl/tutorials/loadflow/LoadflowTutorial.java
+++ b/loadflow/src/main/java/com/powsybl/tutorials/loadflow/LoadflowTutorial.java
@@ -103,7 +103,6 @@ public final class LoadflowTutorial {
         // This time, load parameters from config.yml file
         loadflowParams = LoadFlowParameters.load();
         LoadFlow.run(network, loadflowParams);
-        LoadFlow.run(network);
 
         // Let's analyze the results
         printLines(network);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix.


**What is the current behavior?**
<!-- You can also link to an open issue here -->
In the loadflow tutorial, the loadflow computation for the second network variant is done twice. 


**What is the new behavior (if this is a feature change)?**
The loadflow computation for the second network  variant is done only once using the loaded parameters. 


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
