### PR TITLE
Fix dead links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project and everyone participates in it is governed by the [PowSyBl Code of
 
 ## Tutorials
 
-This document describes how to build and run small tutorial projects. For more in depth explanations on each tutorial, please visit the https://www.powsybl.org/pages/documentation/developer/tutorials/ page.
+This document describes how to build and run small tutorial projects. For more in depth explanations on each tutorial, please visit the [documentation](TODO).
 
 ## Environment requirements
 

--- a/downscaling/README.md
+++ b/downscaling/README.md
@@ -1,2 +1,2 @@
 # Write the Java code to map steady state hypothesis on a network
-This tutorial shows how to write Java code to perform downscaling of global study state hypothesis and map the local hypothesis to an existing network. Follow the tutorial step by step in our [web site](https://www.powsybl.org/pages/documentation/developer/tutorials/downscaling.html).
+This tutorial shows how to write Java code to perform downscaling of global study state hypothesis and map the local hypothesis to an existing network. Follow the tutorial step by step in our [website](TODO).

--- a/emf/README.md
+++ b/emf/README.md
@@ -1,9 +1,9 @@
 # European Merging Function tutorial
 
-In this tutorial, we will learn how to import multiple IGMs in CIM-CGMES format, merge them and compute a load flow on the resulting CGM. Then we will learn how to balance the AC net positions of the merged control areas and export the results in a SV file. For full documentation, please visit [this page](https://www.powsybl.org/pages/documentation/developer/tutorials/emf.html).
+In this tutorial, we will learn how to import multiple IGMs in CIM-CGMES format, merge them and compute a load flow on the resulting CGM. Then we will learn how to balance the AC net positions of the merged control areas and export the results in a SV file. For full documentation, please visit [this page](TODO).
 
 # How to install the loadflow simulator  
-In the tutorial, we use the OpenLoadFlow implementation. Please visit this page to learn more about [OpenLoadFlow](https://www.powsybl.org/pages/documentation/simulation/powerflow/openlf.html).
+In the tutorial, we use the OpenLoadFlow implementation. Please visit this page to learn more about [OpenLoadFlow](https://powsybl.readthedocs.io/projects/powsybl-open-loadflow/en/latest/).
 
 # How to configure this tutorial
 The configuration file is:

--- a/loadflow/README.md
+++ b/loadflow/README.md
@@ -3,7 +3,7 @@ This tutorial aims to compute loadflows on a small fictive network. We first loa
 
 
 # How to install the loadflow simulator  
-In the tutorial, we use the OpenLoadFlow implementation. Please visit this page to learn more about [OpenLoadFlow](https://www.powsybl.org/pages/documentation/simulation/powerflow/openlf.html).
+In the tutorial, we use the OpenLoadFlow implementation. Please visit this page to learn more about [OpenLoadFlow](https://powsybl.readthedocs.io/projects/powsybl-open-loadflow/en/latest/).
 
 # How to configure this tutorial
 The configuration file is:

--- a/merging/README.md
+++ b/merging/README.md
@@ -5,7 +5,7 @@ In this tutorial, we learn how to import IGM CGMES files, merge them, run a load
 Note that the boundary files in CGMES format are stored in each CGMES archive.
 
 # How to install the load flow simulator  
-In the tutorial, we use the OpenLoadFlow implementation. Please visit this [page](https://www.powsybl.org/pages/documentation/simulation/powerflow/openlf.html) for more information about it.
+In the tutorial, we use the OpenLoadFlow implementation. Please visit this [page](https://powsybl.readthedocs.io/projects/powsybl-open-loadflow/en/latest/) for more information about it.
 
 # How to configure this tutorial
 The configuration file is:

--- a/sensitivity/README.md
+++ b/sensitivity/README.md
@@ -22,7 +22,7 @@ In the tutorial, we use [powsybl-open-loadflow](https://github.com/powsybl/powsy
 
 # How to configure this tutorial
 To configure the loadflow, simply change the LoadFlowParameters passed on when launching the simulator with `LoadFlow.run`.
-If you want to use another loadflow implementation, you can use a configuration file to select which implementation you want, as specified in the [loadflow documentation](https://www.powsybl.org/pages/documentation/simulation/powerflow/#configuration).
+If you want to use another loadflow implementation, you can use a configuration file to select which implementation you want, as specified in the [loadflow documentation](https://powsybl.readthedocs.io/projects/powsybl-core/en/stable/simulation/loadflow/configuration.html).
 Or simply ensure that there is only one LoadFlowProvider in the classpath (remove the powsybl-open-loadflow artifact from the pom.xml).
 
 # Running the tutorial


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Docs update


**What is the current behavior?**
<!-- You can also link to an open issue here -->
The readme referenced some links from recently moved documentation on powsybl.org. They are changed.


**What is the new behavior (if this is a feature change)?**
The links refer to readthedocs or are replaced by TODOs when referring to the readthedocs of Powsybl tutorials which is not yet available.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No