### PR TITLE
fix(exec tutorials): pass powsybl.config.dirs via JVM args for exec:exec@run

### DIFF
--- a/downscaling/pom.xml
+++ b/downscaling/pom.xml
@@ -18,6 +18,7 @@
         <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
         <exec.mainClass>com.powsybl.tutorials.downscaling.Downscaling</exec.mainClass>
         <exec.optionalArgument>${project.build.directory}/tutorial/output/dir</exec.optionalArgument>
+        <exec.optionalSystemArgs>-Dpowsybl.config.dirs=${project.basedir}/src/main/resources</exec.optionalSystemArgs>
     </properties>
 
     <build>
@@ -25,15 +26,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <key>powsybl.config.dirs</key>
-                            <value>${project.build.directory}/classes</value>
-                        </systemProperty>
-                    </systemProperties>
-                    <classpathScope>compile</classpathScope>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/downscaling/pom.xml
+++ b/downscaling/pom.xml
@@ -18,7 +18,7 @@
         <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
         <exec.mainClass>com.powsybl.tutorials.downscaling.Downscaling</exec.mainClass>
         <exec.optionalArgument>${project.build.directory}/tutorial/output/dir</exec.optionalArgument>
-        <exec.optionalSystemArgs>-Dpowsybl.config.dirs=${project.basedir}/src/main/resources</exec.optionalSystemArgs>
+        <exec.optionalSystemArgs>-Dpowsybl.config.dirs=${project.basedir}/target/classes</exec.optionalSystemArgs>
     </properties>
 
     <build>

--- a/loadflow/pom.xml
+++ b/loadflow/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
         <exec.mainClass>com.powsybl.tutorials.loadflow.LoadflowTutorial</exec.mainClass>
+        <exec.optionalSystemArgs>-Dpowsybl.config.dirs=${project.basedir}/src/main/resources</exec.optionalSystemArgs>
     </properties>
 
     <build>
@@ -24,14 +25,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <key>powsybl.config.dirs</key>
-                            <value>${project.basedir}/src/main/resources</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/merging/pom.xml
+++ b/merging/pom.xml
@@ -16,6 +16,7 @@
     <properties>
         <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
         <exec.mainClass>com.powsybl.tutorials.merging.MergingTutorial</exec.mainClass>
+        <exec.optionalSystemArgs>-Dpowsybl.config.dirs=${project.basedir}/src/main/resources</exec.optionalSystemArgs>
     </properties>
 
     <build>
@@ -23,14 +24,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <key>powsybl.config.dirs</key>
-                            <value>${project.basedir}/src/main/resources</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,9 @@
         <powsybl.metrix.version>3.0.0</powsybl.metrix.version>
         <fastcsv.version>4.0.0</fastcsv.version> <!-- This dependency will be removed once FastCSV is used in powsybl-core -->
 
-        <exec.mainClass/> <!-- To be defined in sub-modules -->
-        <exec.optionalArgument/> <!-- To be defined in sub-modules -->
+        <exec.optionalSystemArgs/> <!-- To be defined or not in submodules -->
+        <exec.mainClass/> <!-- To be defined in submodules -->
+        <exec.optionalArgument/> <!-- To be defined in submodules -->
     </properties>
 
     <modules>
@@ -67,13 +68,9 @@
                             </goals>
                             <configuration>
                                 <executable>java</executable>
-                                <arguments>
-                                    <argument>-cp</argument>
-                                    <!-- computed project classpath -->
-                                    <classpath/>
-                                    <argument>${exec.mainClass}</argument>
-                                    <argument>${exec.optionalArgument}</argument>
-                                </arguments>
+                                <commandlineArgs>
+                                    ${exec.optionalSystemArgs} -cp %classpath ${exec.mainClass} ${exec.optionalArgument}
+                                </commandlineArgs>
                             </configuration>
                         </execution>
                     </executions>

--- a/security-analysis/pom.xml
+++ b/security-analysis/pom.xml
@@ -17,6 +17,7 @@
     <properties>
         <exec.cleanupDaemonThreads>false</exec.cleanupDaemonThreads>
         <exec.mainClass>com.powsybl.tutorials.sa.SecurityAnalysisTutorials</exec.mainClass>
+        <exec.optionalSystemArgs>-Dpowsybl.config.dirs=${project.basedir}/src/main/resources</exec.optionalSystemArgs>
     </properties>
 
     <build>
@@ -24,14 +25,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <configuration>
-                    <systemProperties>
-                        <systemProperty>
-                            <key>powsybl.config.dirs</key>
-                            <value>${project.basedir}/src/main/resources</value>
-                        </systemProperty>
-                    </systemProperties>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
Fixes #85 

**What kind of change does this PR introduce?**
Bug fix

**What is the current behavior?**

**What is the new behavior (if this is a feature change)?**

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**

**Other information**:
- [x] Added new argument (system arg) at the begening of the command (mvn exec:exec) to take into account the config.yml if wanted. 
- [x]  Used `commandlineArgs` instead of new `<argument>` field because, optional field when absent gives empty which is not of type [argument](https://www.mojohaus.org/exec-maven-plugin/exec-mojo.html#arguments) => switch to [commandlineArgs](https://www.mojohaus.org/exec-maven-plugin/exec-mojo.html#commandlineArgs)